### PR TITLE
Fix scrolling the RepeatingList on mobile devices

### DIFF
--- a/client/components/RepeatingList/RepeatingList.css
+++ b/client/components/RepeatingList/RepeatingList.css
@@ -3,7 +3,7 @@ repeating-list {
     display: flex;
     overflow: hidden;
 }
-repeating-list:hover {
+repeating-list:hover, repeating-list:active {
     overflow: scroll;
 }
 @media (prefers-reduced-motion: reduce) {

--- a/client/components/RepeatingList/RepeatingList.js
+++ b/client/components/RepeatingList/RepeatingList.js
@@ -126,7 +126,7 @@ class RepeatingList extends HTMLElement {
 			this.#lastRenderWasFrozen = false;
 			const speed = this.#getSpeed();
 			// Auto-scroll if the user isn't hovering.
-			if(!this.matches(":hover") && this.#lastRenderTimestamp !== null) {
+			if(!this.matches(":hover") && !this.matches(":active") && this.#lastRenderTimestamp !== null) {
 				const timeDiff = timestamp - this.#lastRenderTimestamp;
 				this.scrollLeft += timeDiff / (this.#speedMultiplier / speed);
 			}


### PR DESCRIPTION
This makes it slightly easier for users to manually scroll / stop the automatic scrolling of RepeatingLists while using touch screen devices.

This fixes #22.