### PR TITLE
Fix floating point scrollLeft bug

### DIFF
--- a/client/components/RepeatingList/RepeatingList.js
+++ b/client/components/RepeatingList/RepeatingList.js
@@ -158,7 +158,7 @@ class RepeatingList extends HTMLElement {
         }
 
         // Once we've reached at least one full pixel, scroll by that pixel(s) and then remove it from the next scroll.
-        if(Math.abs(this.#nextScrollLeft) >= 1) {
+        if (Math.abs(this.#nextScrollLeft) >= 1) {
             this.scrollLeft += Math.trunc(this.#nextScrollLeft);
             this.#nextScrollLeft = this.#nextScrollLeft % 1;
         }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2196,9 +2196,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
+      "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3706,9 +3706,9 @@
       }
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
+      "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
       "dev": true
     },
     "wrap-ansi": {


### PR DESCRIPTION
Fix a bug with scrolling not working properly on some browsers where scrollLeft cannot take a floating point value. This works fine in Edge interestingly, but did not work in Chrome or Firefox. Now we instead store the value until it's greater than 1, and then add the integer value on the next available frame.