### PR TITLE
Fix profile link icons on Safari

### DIFF
--- a/client/components/SelfIntro/SelfIntro.css
+++ b/client/components/SelfIntro/SelfIntro.css
@@ -43,6 +43,7 @@
 }
 
 .profile-btn.linkedin {
+  position: relative;
   color: rgb(45, 100, 188);
 }
 
@@ -61,6 +62,7 @@
 }
 
 .profile-btn.npm {
+  position: relative;
   color: rgb(186, 38, 26);
 }
 


### PR DESCRIPTION
The LinkedIn and NPM icon white backgrounds on Safari browsers were not constrained to the inside of their icons. Adding relative positioning to their parent fixes this.